### PR TITLE
Implement APS checkpoints 7-8: cursor_rules and skills root adapter

### DIFF
--- a/APS-v0-spec.md
+++ b/APS-v0-spec.md
@@ -15,8 +15,8 @@ This document defines the **v0 specification** for **APS (Agentic Prompt Sync)**
 | 4 | Filesystem Source + `agents_md` | ✅ Complete |
 | 5 | Conflict Handling | ✅ Complete |
 | 6 | Lockfile + `aps status` | ✅ Complete |
-| 7 | Directory Install (`cursor_rules`) | ⏳ Pending |
-| 8 | Skills Root Adapter | ⏳ Pending |
+| 7 | Directory Install (`cursor_rules`) | ✅ Complete |
+| 8 | Skills Root Adapter | ✅ Complete |
 | 9 | Git Source (Read-only) | ⏳ Pending |
 | 10 | Git Source Install | ⏳ Pending |
 | 11 | Polish | ⏳ Pending |
@@ -311,17 +311,20 @@ Each checkpoint results in a working CLI.
 
 ---
 
-### Checkpoint 7 — Directory Install (`cursor_rules`) ⏳ PENDING
-- Recursive copy
-- Conflict detection
-- Checksums
+### Checkpoint 7 — Directory Install (`cursor_rules`) ✅ COMPLETE
+- Recursive directory copy preserving structure
+- Conflict detection with backup creation
+- SHA256 checksums for no-op detection
 
-**Note:** Basic directory copy is implemented but needs cursor_rules-specific handling.
+**Implementation:** `src/install.rs::copy_directory()`
 
-### Checkpoint 8 — Skills Root Adapter ⏳ PENDING
-- Skill folder fan-out
-- `SKILL.md` warnings
-- `--strict` enforcement
+### Checkpoint 8 — Skills Root Adapter ✅ COMPLETE
+- Skill folder fan-out: each immediate child directory treated as a skill
+- `SKILL.md` warnings shown when missing (case-sensitive check)
+- `--strict` flag turns warnings into errors (supported in both `pull` and `validate`)
+- Skills still copied even with warnings (unless `--strict`)
+
+**Implementation:** `src/install.rs::install_skills_root()`, `validate_skills_root()`, `src/commands.rs::validate_skills_directory()`
 
 ### Checkpoint 9 — Git Source (Read-only) ⏳ PENDING
 - Clone/fetch

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -72,6 +72,10 @@ pub struct PullArgs {
     /// Show what would be done without making changes
     #[arg(long)]
     pub dry_run: bool,
+
+    /// Treat warnings as errors (e.g., missing SKILL.md)
+    #[arg(long)]
+    pub strict: bool,
 }
 
 #[derive(Parser, Debug)]

--- a/src/error.rs
+++ b/src/error.rs
@@ -80,6 +80,13 @@ pub enum ApsError {
         help("Run `aps pull` first to create a lockfile")
     )]
     LockfileNotFound,
+
+    #[error("Skill missing SKILL.md: {skill_name}")]
+    #[diagnostic(
+        code(aps::skill::missing_skill_md),
+        help("Create a SKILL.md file in the skill directory, or remove --strict to continue with a warning")
+    )]
+    SkillMdMissing { skill_name: String },
 }
 
 impl ApsError {

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,5 +44,5 @@ fn main() -> Result<()> {
     };
 
     // Convert our error type to miette for nice display
-    result.map_err(|e| miette::miette!("{:?}", e))
+    result.map_err(|e| miette::miette!("{}", e))
 }

--- a/test-fixtures/shared-assets/AGENTS.md
+++ b/test-fixtures/shared-assets/AGENTS.md
@@ -1,0 +1,3 @@
+# AGENTS.md
+
+This is the AGENTS.md file.

--- a/test-fixtures/shared-assets/rules/general.mdc
+++ b/test-fixtures/shared-assets/rules/general.mdc
@@ -1,0 +1,7 @@
+---
+description: General Cursor Rules
+---
+
+# General Rules
+
+These are general cursor rules.

--- a/test-fixtures/shared-assets/skills/skill-one/SKILL.md
+++ b/test-fixtures/shared-assets/skills/skill-one/SKILL.md
@@ -1,0 +1,3 @@
+# Skill One
+
+This is skill one with a proper SKILL.md file.

--- a/test-fixtures/shared-assets/skills/skill-one/code.py
+++ b/test-fixtures/shared-assets/skills/skill-one/code.py
@@ -1,0 +1,2 @@
+def skill_one():
+    return "Hello from skill one"

--- a/test-fixtures/shared-assets/skills/skill-two/code.py
+++ b/test-fixtures/shared-assets/skills/skill-two/code.py
@@ -1,0 +1,2 @@
+def skill_two():
+    return "Hello from skill two - no SKILL.md"

--- a/test-fixtures/test-project/promptsync.yaml
+++ b/test-fixtures/test-project/promptsync.yaml
@@ -1,0 +1,19 @@
+entries:
+  - id: my-agents
+    kind: agents_md
+    source:
+      type: filesystem
+      root: ../shared-assets
+    path: AGENTS.md
+  - id: my-rules
+    kind: cursor_rules
+    source:
+      type: filesystem
+      root: ../shared-assets
+    path: rules
+  - id: my-skills
+    kind: cursor_skills_root
+    source:
+      type: filesystem
+      root: ../shared-assets
+    path: skills


### PR DESCRIPTION
- Checkpoint 7: Directory install for cursor_rules
  - Recursive copy preserving directory structure
  - Conflict detection with backup creation
  - SHA256 checksums for no-op detection

- Checkpoint 8: Skills root adapter with SKILL.md validation
  - Each immediate child directory treated as a skill
  - Warning when SKILL.md missing (case-sensitive)
  - --strict flag turns warnings into errors
  - Skills still copied with warnings unless --strict

Also includes:
- Add --strict flag to pull command
- Add SkillMdMissing error type
- Fix error display to use Display instead of Debug format
- Add test fixtures for testing skills and rules