### PR TITLE
Rename file pattern from promptsync.yaml to aps.yaml

### DIFF
--- a/APS-v0-spec.md
+++ b/APS-v0-spec.md
@@ -42,8 +42,8 @@ src/
 
 - **Tool name:** aps
 - **Binary:** `aps`
-- **Manifest:** `promptsync.yaml` (default)
-- **Lockfile:** `.promptsync.lock`
+- **Manifest:** `aps.yaml` (default)
+- **Lockfile:** `.aps.lock`
 - **Backups:** `.aps-backups/`
 
 ---
@@ -177,7 +177,7 @@ If install would overwrite existing content:
 
 ## Lockfile
 
-Stored at `.promptsync.lock`.
+Stored at `.aps.lock`.
 
 Per item:
 
@@ -267,8 +267,8 @@ Each checkpoint results in a working CLI.
 **Implementation:** `src/main.rs`, `src/cli.rs`
 
 ### Checkpoint 1 — `aps init` ✅ COMPLETE
-- Creates `promptsync.yaml` manifest with example entry
-- Adds `.promptsync.lock` and `.aps-backups/` to `.gitignore`
+- Creates `aps.yaml` manifest with example entry
+- Adds `.aps.lock` and `.aps-backups/` to `.gitignore`
 - Idempotent behavior (errors if manifest exists)
 
 **Implementation:** `src/commands.rs::cmd_init()`
@@ -302,7 +302,7 @@ Each checkpoint results in a working CLI.
 **Implementation:** `src/backup.rs`, `src/install.rs`
 
 ### Checkpoint 6 — Lockfile + `aps status` ✅ COMPLETE
-- Write `.promptsync.lock` after install with:
+- Write `.aps.lock` after install with:
   - source, dest, resolved_ref, commit, last_updated_at, checksum
 - SHA256 checksums enable no-op detection (idempotent pulls)
 - `aps status` displays all synced entries with formatted output

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The binary will be available at `target/release/aps`.
 aps init
 ```
 
-This creates a `promptsync.yaml` manifest file with an example entry.
+This creates a `aps.yaml` manifest file with an example entry.
 
 2. **Edit the manifest** to define your assets:
 
@@ -75,7 +75,7 @@ aps status
 ### Common Options
 
 - `--verbose` - Enable verbose logging
-- `--manifest <path>` - Specify manifest file path (default: `promptsync.yaml`)
+- `--manifest <path>` - Specify manifest file path (default: `aps.yaml`)
 
 ### Pull Options
 
@@ -85,7 +85,7 @@ aps status
 
 ## Configuration
 
-### Manifest File (`promptsync.yaml`)
+### Manifest File (`aps.yaml`)
 
 ```yaml
 entries:
@@ -106,7 +106,7 @@ entries:
 | `cursor_rules` | Directory of Cursor rules | `./.cursor/rules/` |
 | `cursor_skills_root` | Directory with skill subdirs | `./.cursor/skills/` |
 
-### Lockfile (`.promptsync.lock`)
+### Lockfile (`.aps.lock`)
 
 The lockfile tracks installed assets and is automatically created/updated by `aps pull`. It stores:
 

--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -6,7 +6,7 @@ use std::path::{Path, PathBuf};
 use tracing::{debug, info};
 
 /// Default lockfile filename
-pub const LOCKFILE_NAME: &str = ".promptsync.lock";
+pub const LOCKFILE_NAME: &str = ".aps.lock";
 
 /// The lockfile structure
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -5,7 +5,7 @@ use std::path::{Path, PathBuf};
 use tracing::{debug, info};
 
 /// Default manifest filename
-pub const DEFAULT_MANIFEST_NAME: &str = "promptsync.yaml";
+pub const DEFAULT_MANIFEST_NAME: &str = "aps.yaml";
 
 /// The main manifest structure
 #[derive(Debug, Serialize, Deserialize, Clone)]


### PR DESCRIPTION
Update default manifest and lockfile names:
- Manifest: promptsync.yaml → aps.yaml
- Lockfile: .promptsync.lock → .aps.lock

This simplifies the file naming to match the tool name (aps).