### PR TITLE
refactor: migrate existing code to adapter pattern

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ mod git;
 mod install;
 mod lockfile;
 mod manifest;
+mod sources;
 
 use clap::Parser;
 use cli::{Cli, Commands};

--- a/src/sources/filesystem.rs
+++ b/src/sources/filesystem.rs
@@ -1,0 +1,169 @@
+//! Filesystem source adapter for local file system sources.
+
+use crate::error::Result;
+use crate::sources::{AsAny, ResolvedSource, SourceAdapter};
+use serde::{Deserialize, Serialize};
+use std::any::Any;
+use std::path::{Path, PathBuf};
+
+/// Local filesystem source.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FilesystemSource {
+    /// Root directory for resolving paths
+    pub root: String,
+    /// Optional path within the root directory
+    #[serde(default)]
+    pub path: Option<String>,
+    /// Whether to create symlinks instead of copying files (default: true)
+    #[serde(default = "default_symlink")]
+    pub symlink: bool,
+}
+
+fn default_symlink() -> bool {
+    true
+}
+
+impl AsAny for FilesystemSource {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}
+
+impl SourceAdapter for FilesystemSource {
+    fn source_type(&self) -> &'static str {
+        "filesystem"
+    }
+
+    fn display_name(&self) -> String {
+        format!("filesystem:{}", self.root)
+    }
+
+    fn resolve(&self, manifest_dir: &Path) -> Result<ResolvedSource> {
+        let root_path = if Path::new(&self.root).is_absolute() {
+            PathBuf::from(&self.root)
+        } else {
+            manifest_dir.join(&self.root)
+        };
+
+        let path = self.path();
+        let source_path = if path == "." {
+            root_path
+        } else {
+            root_path.join(path)
+        };
+
+        Ok(ResolvedSource {
+            source_path,
+            source_display: self.display_name(),
+            git_info: None,
+            use_symlink: self.symlink,
+            _temp_holder: None,
+        })
+    }
+
+    fn supports_symlink(&self) -> bool {
+        true
+    }
+
+    fn path(&self) -> &str {
+        self.path.as_deref().unwrap_or(".")
+    }
+
+    fn clone_box(&self) -> Box<dyn SourceAdapter> {
+        Box::new(self.clone())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+    use tempfile::TempDir;
+
+    #[test]
+    fn test_source_type() {
+        let source = FilesystemSource {
+            root: "/tmp/test".to_string(),
+            path: None,
+            symlink: true,
+        };
+        assert_eq!(source.source_type(), "filesystem");
+    }
+
+    #[test]
+    fn test_display_name() {
+        let source = FilesystemSource {
+            root: "/tmp/test".to_string(),
+            path: None,
+            symlink: true,
+        };
+        assert_eq!(source.display_name(), "filesystem:/tmp/test");
+    }
+
+    #[test]
+    fn test_supports_symlink() {
+        let source = FilesystemSource {
+            root: "/tmp/test".to_string(),
+            path: None,
+            symlink: true,
+        };
+        assert!(source.supports_symlink());
+    }
+
+    #[test]
+    fn test_path_default() {
+        let source = FilesystemSource {
+            root: "/tmp/test".to_string(),
+            path: None,
+            symlink: true,
+        };
+        assert_eq!(source.path(), ".");
+    }
+
+    #[test]
+    fn test_path_custom() {
+        let source = FilesystemSource {
+            root: "/tmp/test".to_string(),
+            path: Some("subdir".to_string()),
+            symlink: true,
+        };
+        assert_eq!(source.path(), "subdir");
+    }
+
+    #[test]
+    fn test_resolve_absolute_root() {
+        let temp_dir = TempDir::new().unwrap();
+        let root = temp_dir.path().to_string_lossy().to_string();
+
+        let source = FilesystemSource {
+            root: root.clone(),
+            path: None,
+            symlink: true,
+        };
+
+        let manifest_dir = PathBuf::from("/some/other/path");
+        let resolved = source.resolve(&manifest_dir).unwrap();
+
+        assert_eq!(resolved.source_path, temp_dir.path());
+        assert!(resolved.use_symlink);
+        assert!(resolved.git_info.is_none());
+    }
+
+    #[test]
+    fn test_resolve_relative_root() {
+        let source = FilesystemSource {
+            root: "../shared".to_string(),
+            path: Some("assets".to_string()),
+            symlink: false,
+        };
+
+        let manifest_dir = PathBuf::from("/home/user/project");
+        let resolved = source.resolve(&manifest_dir).unwrap();
+
+        assert_eq!(
+            resolved.source_path,
+            PathBuf::from("/home/user/project/../shared/assets")
+        );
+        assert!(!resolved.use_symlink);
+    }
+}

--- a/src/sources/git.rs
+++ b/src/sources/git.rs
@@ -1,0 +1,161 @@
+//! Git source adapter for git repository sources.
+
+use crate::error::Result;
+use crate::git::clone_and_resolve;
+use crate::sources::{AsAny, GitInfo, ResolvedSource, SourceAdapter};
+use serde::{Deserialize, Serialize};
+use std::any::Any;
+use std::path::Path;
+
+/// Git repository source.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GitSource {
+    /// Repository URL (SSH or HTTPS)
+    #[serde(alias = "url")]
+    pub repo: String,
+    /// Git ref (branch, tag, commit) - "auto" tries main then master
+    #[serde(default = "default_ref")]
+    pub r#ref: String,
+    /// Whether to use shallow clone
+    #[serde(default = "default_shallow")]
+    pub shallow: bool,
+    /// Optional path within the repository
+    #[serde(default)]
+    pub path: Option<String>,
+}
+
+fn default_ref() -> String {
+    "auto".to_string()
+}
+
+fn default_shallow() -> bool {
+    true
+}
+
+impl AsAny for GitSource {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}
+
+impl SourceAdapter for GitSource {
+    fn source_type(&self) -> &'static str {
+        "git"
+    }
+
+    fn display_name(&self) -> String {
+        self.repo.clone()
+    }
+
+    fn resolve(&self, _manifest_dir: &Path) -> Result<ResolvedSource> {
+        println!("Fetching from git: {}", self.repo);
+        let resolved = clone_and_resolve(&self.repo, &self.r#ref, self.shallow)?;
+
+        let path = self.path();
+        let source_path = if path == "." {
+            resolved.repo_path.clone()
+        } else {
+            resolved.repo_path.join(path)
+        };
+
+        let git_info = GitInfo {
+            resolved_ref: resolved.resolved_ref.clone(),
+            commit_sha: resolved.commit_sha.clone(),
+        };
+
+        Ok(ResolvedSource {
+            source_path,
+            source_display: self.display_name(),
+            git_info: Some(git_info),
+            use_symlink: false, // Git sources always copy (temp dir)
+            _temp_holder: Some(Box::new(resolved)),
+        })
+    }
+
+    fn supports_symlink(&self) -> bool {
+        false // Git sources always copy from temp dir
+    }
+
+    fn path(&self) -> &str {
+        self.path.as_deref().unwrap_or(".")
+    }
+
+    fn clone_box(&self) -> Box<dyn SourceAdapter> {
+        Box::new(self.clone())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_source_type() {
+        let source = GitSource {
+            repo: "https://github.com/example/repo.git".to_string(),
+            r#ref: "main".to_string(),
+            shallow: true,
+            path: None,
+        };
+        assert_eq!(source.source_type(), "git");
+    }
+
+    #[test]
+    fn test_display_name() {
+        let source = GitSource {
+            repo: "https://github.com/example/repo.git".to_string(),
+            r#ref: "main".to_string(),
+            shallow: true,
+            path: None,
+        };
+        assert_eq!(
+            source.display_name(),
+            "https://github.com/example/repo.git"
+        );
+    }
+
+    #[test]
+    fn test_supports_symlink() {
+        let source = GitSource {
+            repo: "https://github.com/example/repo.git".to_string(),
+            r#ref: "main".to_string(),
+            shallow: true,
+            path: None,
+        };
+        assert!(!source.supports_symlink());
+    }
+
+    #[test]
+    fn test_path_default() {
+        let source = GitSource {
+            repo: "https://github.com/example/repo.git".to_string(),
+            r#ref: "main".to_string(),
+            shallow: true,
+            path: None,
+        };
+        assert_eq!(source.path(), ".");
+    }
+
+    #[test]
+    fn test_path_custom() {
+        let source = GitSource {
+            repo: "https://github.com/example/repo.git".to_string(),
+            r#ref: "main".to_string(),
+            shallow: true,
+            path: Some("src/assets".to_string()),
+        };
+        assert_eq!(source.path(), "src/assets");
+    }
+
+    #[test]
+    fn test_default_values() {
+        // Test deserialization with defaults
+        let yaml = r#"
+            repo: https://github.com/example/repo.git
+        "#;
+        let source: GitSource = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(source.r#ref, "auto");
+        assert!(source.shallow);
+        assert!(source.path.is_none());
+    }
+}

--- a/src/sources/mod.rs
+++ b/src/sources/mod.rs
@@ -1,0 +1,94 @@
+//! Source adapters for different content sources.
+//!
+//! This module provides a trait-based abstraction for different source types
+//! (git, filesystem, etc.) allowing for easy extensibility.
+
+pub mod filesystem;
+pub mod git;
+pub mod registry;
+
+use crate::error::Result;
+use crate::lockfile::LockedEntry;
+use std::any::Any;
+use std::fmt::Debug;
+use std::path::{Path, PathBuf};
+
+pub use filesystem::FilesystemSource;
+pub use git::GitSource;
+pub use registry::SourceRegistry;
+
+/// Helper trait for downcasting trait objects to concrete types.
+pub trait AsAny {
+    fn as_any(&self) -> &dyn Any;
+}
+
+/// A source that can provide content for installation.
+///
+/// Implementors of this trait provide a way to resolve content from
+/// various sources (git repositories, local filesystem, etc.) into
+/// a local path that can be installed.
+pub trait SourceAdapter: Send + Sync + Debug + AsAny {
+    /// Unique identifier for this source type (e.g., "git", "filesystem", "s3")
+    fn source_type(&self) -> &'static str;
+
+    /// Human-readable display name for logging
+    fn display_name(&self) -> String;
+
+    /// Resolve the source and return the path to content.
+    /// Returns a ResolvedSource that may hold temporary resources.
+    fn resolve(&self, manifest_dir: &Path) -> Result<ResolvedSource>;
+
+    /// Whether this source supports symlinking (vs. must copy)
+    fn supports_symlink(&self) -> bool;
+
+    /// Get the path within the source (defaults to "." if not specified)
+    fn path(&self) -> &str;
+
+    /// Optional: Check if remote has changed without fetching content.
+    /// Returns None if check not supported, Some(true) if changed, Some(false) if same.
+    fn has_remote_changed(&self, _lockfile_entry: Option<&LockedEntry>) -> Result<Option<bool>> {
+        Ok(None) // Default: don't know, must fetch
+    }
+
+    /// Clone this source adapter into a boxed trait object
+    fn clone_box(&self) -> Box<dyn SourceAdapter>;
+}
+
+impl Clone for Box<dyn SourceAdapter> {
+    fn clone(&self) -> Self {
+        self.clone_box()
+    }
+}
+
+/// Git-specific resolution info
+#[derive(Debug, Clone)]
+pub struct GitInfo {
+    pub resolved_ref: String,
+    pub commit_sha: String,
+}
+
+/// Resolved source information ready for installation.
+pub struct ResolvedSource {
+    /// Path to the actual source content
+    pub source_path: PathBuf,
+    /// Display name for the source
+    pub source_display: String,
+    /// Git-specific info (if applicable)
+    pub git_info: Option<GitInfo>,
+    /// Whether to create symlinks instead of copying
+    pub use_symlink: bool,
+    /// Holds temp resources (e.g., cloned git repo) until installation complete
+    pub _temp_holder: Option<Box<dyn Any + Send>>,
+}
+
+impl Debug for ResolvedSource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ResolvedSource")
+            .field("source_path", &self.source_path)
+            .field("source_display", &self.source_display)
+            .field("git_info", &self.git_info)
+            .field("use_symlink", &self.use_symlink)
+            .field("_temp_holder", &self._temp_holder.is_some())
+            .finish()
+    }
+}

--- a/src/sources/registry.rs
+++ b/src/sources/registry.rs
@@ -1,0 +1,195 @@
+//! Source registry for dynamic source type parsing.
+
+use crate::error::{ApsError, Result};
+use crate::sources::{FilesystemSource, GitSource, SourceAdapter};
+use std::collections::HashMap;
+
+type ParserFn = Box<dyn Fn(&serde_yaml::Value) -> Result<Box<dyn SourceAdapter>> + Send + Sync>;
+
+/// Registry for source type parsers.
+///
+/// This allows dynamic registration and parsing of source types,
+/// making it easy to add new source types without modifying core code.
+pub struct SourceRegistry {
+    parsers: HashMap<String, ParserFn>,
+}
+
+impl Default for SourceRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SourceRegistry {
+    /// Create a new registry with built-in source types registered.
+    pub fn new() -> Self {
+        let mut registry = Self {
+            parsers: HashMap::new(),
+        };
+
+        // Register built-in source types
+        registry.register("filesystem", |v| {
+            let source: FilesystemSource =
+                serde_yaml::from_value(v.clone()).map_err(|e| ApsError::ManifestParseError {
+                    message: format!("Failed to parse filesystem source: {}", e),
+                })?;
+            Ok(Box::new(source) as Box<dyn SourceAdapter>)
+        });
+
+        registry.register("git", |v| {
+            let source: GitSource =
+                serde_yaml::from_value(v.clone()).map_err(|e| ApsError::ManifestParseError {
+                    message: format!("Failed to parse git source: {}", e),
+                })?;
+            Ok(Box::new(source) as Box<dyn SourceAdapter>)
+        });
+
+        registry
+    }
+
+    /// Register a new source type parser.
+    pub fn register<F>(&mut self, source_type: &str, parser: F)
+    where
+        F: Fn(&serde_yaml::Value) -> Result<Box<dyn SourceAdapter>> + Send + Sync + 'static,
+    {
+        self.parsers.insert(source_type.to_string(), Box::new(parser));
+    }
+
+    /// Parse a source value into a SourceAdapter.
+    ///
+    /// The value should be a YAML mapping with a "type" field indicating
+    /// the source type.
+    pub fn parse(&self, value: &serde_yaml::Value) -> Result<Box<dyn SourceAdapter>> {
+        let source_type = value
+            .get("type")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| ApsError::ManifestParseError {
+                message: "Source must have a 'type' field".to_string(),
+            })?;
+
+        self.parse_typed(source_type, value)
+    }
+
+    /// Parse a source value with a known type.
+    pub fn parse_typed(
+        &self,
+        source_type: &str,
+        value: &serde_yaml::Value,
+    ) -> Result<Box<dyn SourceAdapter>> {
+        let parser = self.parsers.get(source_type).ok_or_else(|| {
+            ApsError::InvalidSourceType {
+                source_type: source_type.to_string(),
+            }
+        })?;
+
+        parser(value)
+    }
+
+    /// Get list of registered source types.
+    #[allow(dead_code)]
+    pub fn registered_types(&self) -> Vec<&str> {
+        self.parsers.keys().map(|s| s.as_str()).collect()
+    }
+}
+
+/// Global registry instance for convenience.
+/// In a real application, you might want to use dependency injection instead.
+#[allow(dead_code)]
+pub fn default_registry() -> SourceRegistry {
+    SourceRegistry::new()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_registry_has_builtin_types() {
+        let registry = SourceRegistry::new();
+        let types = registry.registered_types();
+        assert!(types.contains(&"filesystem"));
+        assert!(types.contains(&"git"));
+    }
+
+    #[test]
+    fn test_parse_filesystem_source() {
+        let registry = SourceRegistry::new();
+        let yaml = serde_yaml::from_str::<serde_yaml::Value>(
+            r#"
+            type: filesystem
+            root: ../shared
+            symlink: true
+        "#,
+        )
+        .unwrap();
+
+        let source = registry.parse(&yaml).unwrap();
+        assert_eq!(source.source_type(), "filesystem");
+        assert_eq!(source.display_name(), "filesystem:../shared");
+    }
+
+    #[test]
+    fn test_parse_git_source() {
+        let registry = SourceRegistry::new();
+        let yaml = serde_yaml::from_str::<serde_yaml::Value>(
+            r#"
+            type: git
+            repo: https://github.com/example/repo.git
+            ref: main
+        "#,
+        )
+        .unwrap();
+
+        let source = registry.parse(&yaml).unwrap();
+        assert_eq!(source.source_type(), "git");
+        assert_eq!(source.display_name(), "https://github.com/example/repo.git");
+    }
+
+    #[test]
+    fn test_parse_unknown_type() {
+        let registry = SourceRegistry::new();
+        let yaml = serde_yaml::from_str::<serde_yaml::Value>(
+            r#"
+            type: s3
+            bucket: my-bucket
+        "#,
+        )
+        .unwrap();
+
+        let result = registry.parse(&yaml);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_parse_missing_type() {
+        let registry = SourceRegistry::new();
+        let yaml = serde_yaml::from_str::<serde_yaml::Value>(
+            r#"
+            root: ../shared
+        "#,
+        )
+        .unwrap();
+
+        let result = registry.parse(&yaml);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_custom_source_registration() {
+        use crate::sources::FilesystemSource;
+
+        let mut registry = SourceRegistry::new();
+        registry.register("custom", |v| {
+            // Just reuse filesystem for testing
+            let source: FilesystemSource = serde_yaml::from_value(v.clone()).map_err(|e| {
+                ApsError::ManifestParseError {
+                    message: format!("Failed to parse custom source: {}", e),
+                }
+            })?;
+            Ok(Box::new(source) as Box<dyn SourceAdapter>)
+        });
+
+        let types = registry.registered_types();
+        assert!(types.contains(&"custom"));
+    }
+}


### PR DESCRIPTION
refactor: implement adapter pattern for source types
This refactoring converts the Source enum to a trait-based adapter pattern
for better extensibility and testability.

Key changes:
- Add src/sources/ module with SourceAdapter trait
- Implement FilesystemSource and GitSource adapters
- Add SourceRegistry for dynamic source type parsing
- Update manifest.rs with custom serde for Box<dyn SourceAdapter>
- Update install.rs to use trait methods instead of match dispatch
- Update commands.rs to use source_type() for validation logic
- Add comprehensive unit tests for all adapters

Benefits:
- New source types (S3, HTTP, etc.) can be added without modifying core
- Each source adapter owns its resolution logic
- Clear interface contract via SourceAdapter trait
- Improved testability with mockable adapters