### PR TITLE
docs: add `aps list` command to README commands table

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ cargo build --release
 | `aps sync`     | Sync all entries from manifest and install assets |
 | `aps validate` | Validate manifest schema and check sources        |
 | `aps status`   | Display last sync information from lockfile       |
+| `aps list`     | List manifest entries and their resources         |
 
 ### Common Options
 
@@ -191,6 +192,10 @@ To skip prompts and add everything, use `--all`. To skip the confirmation, use `
 aps add --all https://github.com/anthropics/skills
 aps add --yes https://github.com/anthropics/skills
 ```
+
+### List Options
+
+- `--assets` - Show on-disk asset tree for synced entries
 
 ### Sync Options
 


### PR DESCRIPTION
The last PR (#76) added the `aps list` command but the README
wasn't updated. Add it to the commands table and document its
`--assets` option.

https://claude.ai/code/session_018aeZn9BGiJ8MXcdribNi3P

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new `aps list` CLI command to list manifest entries and their associated resources.
  * Introduced a `--assets` flag to display the on-disk asset tree for synced entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->